### PR TITLE
Expose charsets as Hash in normalized params

### DIFF
--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -16,6 +16,7 @@ module Griddler
           cc: recipients(:cc).map(&:format),
           bcc: get_bcc,
           attachments: attachment_files,
+          charsets: charsets
         )
       end
 
@@ -39,6 +40,15 @@ module Griddler
       def bcc_from_envelope
         JSON.parse(params[:envelope])["to"] if params[:envelope].present?
       end
+
+      def charsets
+        if params[:charsets].present?
+          JSON.parse(params[:charsets]).symbolize_keys
+        end
+      rescue JSON::ParserError
+        nil
+      end
+
 
       def attachment_files
         attachment_count.times.map do |index|

--- a/lib/griddler/sendgrid/adapter.rb
+++ b/lib/griddler/sendgrid/adapter.rb
@@ -42,11 +42,10 @@ module Griddler
       end
 
       def charsets
-        if params[:charsets].present?
-          JSON.parse(params[:charsets]).symbolize_keys
-        end
+        return {} unless params[:charsets].present?
+        JSON.parse(params[:charsets]).symbolize_keys
       rescue JSON::ParserError
-        nil
+        {}
       end
 
 

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -142,7 +142,12 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
   it 'does not explode if charsets is not JSON-able' do
     params = default_params.merge(charsets: 'This is not JSON')
 
-    normalize_params(params)[:charsets].should be_nil
+    normalize_params(params)[:charsets].should eq({})
+  end
+
+  it 'defaults charsets to an empty hash if it is not specified in params' do
+    params = default_params.except(:charsets)
+    normalize_params(params)[:charsets].should eq({})
   end
 
   def default_params

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -14,6 +14,14 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
       to: 'Hello World <hi@example.com>',
       cc: 'emily@example.com',
       from: 'There <there@example.com>',
+      charsets: {
+        to: 'UTF-8',
+        cc: 'UTF-8',
+        subject: 'UTF-8',
+        from: 'UTF-8',
+        html: 'UTF-8',
+        text: 'iso-8859-1'
+      }.to_json
     }
 
   it 'changes attachments to an array of files' do
@@ -129,6 +137,23 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
     normalized_params[:bcc].should eq []
   end
 
+  it 'returns the charsets as a hash' do
+    normalized_params = normalize_params(default_params)
+    charsets = normalized_params[:charsets]
+
+    charsets.should be_present
+    charsets[:text].should eq 'iso-8859-1'
+
+    %i[to from cc subject html].each do |field|
+      charsets[field].should eq 'UTF-8'
+    end
+  end
+
+  it 'does not explode if charsets is not JSON-able' do
+    params = default_params.merge(charsets: 'This is not JSON')
+
+    normalize_params(params)[:charsets].should be_nil
+  end
   def default_params
     {
       text: 'hi',
@@ -136,6 +161,14 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
       cc: 'cc@example.com',
       from: 'there@example.com',
       envelope: "{\"to\":[\"johny@example.com\"], \"from\": [\"there@example.com\"]}",
+      charsets: {
+        to: 'UTF-8',
+        cc: 'UTF-8',
+        subject: 'UTF-8',
+        from: 'UTF-8',
+        html: 'UTF-8',
+        text: 'iso-8859-1'
+      }.to_json
     }
   end
 end

--- a/spec/griddler/sendgrid/adapter_spec.rb
+++ b/spec/griddler/sendgrid/adapter_spec.rb
@@ -14,14 +14,7 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
       to: 'Hello World <hi@example.com>',
       cc: 'emily@example.com',
       from: 'There <there@example.com>',
-      charsets: {
-        to: 'UTF-8',
-        cc: 'UTF-8',
-        subject: 'UTF-8',
-        from: 'UTF-8',
-        html: 'UTF-8',
-        text: 'iso-8859-1'
-      }.to_json
+      charsets: { to: 'UTF-8', text: 'iso-8859-1' }.to_json
     }
 
   it 'changes attachments to an array of files' do
@@ -143,10 +136,7 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
 
     charsets.should be_present
     charsets[:text].should eq 'iso-8859-1'
-
-    %i[to from cc subject html].each do |field|
-      charsets[field].should eq 'UTF-8'
-    end
+    charsets[:to].should eq 'UTF-8'
   end
 
   it 'does not explode if charsets is not JSON-able' do
@@ -154,6 +144,7 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
 
     normalize_params(params)[:charsets].should be_nil
   end
+
   def default_params
     {
       text: 'hi',
@@ -161,14 +152,7 @@ describe Griddler::Sendgrid::Adapter, '.normalize_params' do
       cc: 'cc@example.com',
       from: 'there@example.com',
       envelope: "{\"to\":[\"johny@example.com\"], \"from\": [\"there@example.com\"]}",
-      charsets: {
-        to: 'UTF-8',
-        cc: 'UTF-8',
-        subject: 'UTF-8',
-        from: 'UTF-8',
-        html: 'UTF-8',
-        text: 'iso-8859-1'
-      }.to_json
+      charsets: { to: 'UTF-8', text: 'iso-8859-1' }.to_json
     }
   end
 end


### PR DESCRIPTION
Based on https://github.com/ygnessin/griddler/pull/4, in tandem with https://github.com/apartmentlist/griddler/pull/1

Parse the JSON string and return a Hash with symbol keys
for ease of use by Griddler later on.